### PR TITLE
fix 404 of dependency

### DIFF
--- a/install.py
+++ b/install.py
@@ -12,7 +12,7 @@ def checking():
 
 if platform.system() == "Linux":
    if not checking():
-      launch.run("apt -y install -qq aria2", "Installing requirements for Model Downloader")
+      launch.run("apt update && apt -y install -qq aria2", "Installing requirements for Model Downloader")
    else:
         pass
 elif platform.system() == "Darwin":


### PR DESCRIPTION
install.py missed apt update thats why sometimes the dependency libc-ares couldn't be found. Running apt update before installing the dependency fixed it for me.